### PR TITLE
feat: add total duration to report summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Robot Reporter
-Robot Reporter is a tool for Robot Framework test reporting. This can be paired with[robotframework-docker-action](https://github.com/joonvena/robotframework-docker-action). When it's run it parses the output.xml file from test results and then sends report as comment to that specific commmit that triggered the test run.  
+Robot Reporter is a tool for Robot Framework test reporting. This can be paired with[robotframework-docker-action](https://github.com/joonvena/robotframework-docker-action). When it's run it parses the output.xml file from test results and then sends report as comment to that specific commit that triggered the test run.  
 
 ![Example](example.png)
 

--- a/assets/template.txt
+++ b/assets/template.txt
@@ -10,7 +10,7 @@
 | Name | :stopwatch: Duration | Suite |
 | --- | :---: | :---: |
 {{range .PassedTests -}}
-| {{.Name}} | {{.ExecutionTime}} s | `{{.Suite}}` |
+| {{.Name}} | {{printf "%.3f" .ExecutionTime}} s | `{{.Suite}}` |
 {{end}}
 {{end -}}
 
@@ -21,7 +21,7 @@
 | Name | Message | :stopwatch: Duration | Suite |
 | --- | --- | :---: | :---: |
 {{range .FailedTests -}}
-| {{.Name}} | {{.Message}} | {{.ExecutionTime}} s | `{{.Suite}}` |
+| {{.Name}} | {{.Message}} | {{printf "%.3f" .ExecutionTime}} s | `{{.Suite}}` |
 {{else}}
 {{end}}
 {{end -}}

--- a/assets/template.txt
+++ b/assets/template.txt
@@ -1,7 +1,7 @@
 ### Robot Results
-| :white_check_mark: Passed | :x: Failed | :next_track_button: Skipped | Total | Pass % |
-| --- | --- | --- | :---: | :---: |
-| {{.Passed}} | {{.Failed}} | {{.Skipped}} | {{.Total}} | {{.PassPercentage}}
+| :white_check_mark: Passed | :x: Failed | :next_track_button: Skipped | Total | Pass % | :stopwatch: Duration |
+| --- | --- | --- | :---: | :---: | :---: |
+| {{.Passed}} | {{.Failed}} | {{.Skipped}} | {{.Total}} | {{.PassPercentage}} | {{.TotalDuration}} |
 
 {{ if or (eq (len .PassedTests) 0) (eq .ShowPassedTests "false") }}
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/antchfx/xmlquery"
 	"github.com/google/go-github/github"
@@ -115,6 +116,7 @@ func main() {
 
 	var failedTests []Test
 	var passedTests []Test
+	var totalDuration float64
 
 	for _, test := range tests {
 		name := test.SelectAttr("name")
@@ -128,6 +130,7 @@ func main() {
 		if err != nil {
 			log.Println(err)
 		}
+		totalDuration += executionTime
 
 		if status == "PASS" {
 			passedTests = append(passedTests, Test{
@@ -176,6 +179,7 @@ func main() {
 	vars["PassPercentage"] = passPercentage(passInt, failInt)
 	vars["PassedTests"] = passedTests
 	vars["FailedTests"] = failedTests
+	vars["TotalDuration"] = time.Duration(totalDuration * float64(time.Second)).String()
 	vars["ShowPassedTests"] = *showPassedTests
 
 	templatelocation := "./assets/template.txt"


### PR DESCRIPTION
Add total test duration to the reporty summary by adding the passed and failed tests.

Other minor changes (appologies, I can push this into separate PRs if required)

* Limit Test duration display to 3 decimal places, as previously durations such as `1.6400000000000001 s` would be displayed.
* Fix minor typo in readme

An example of the duration in the summary is shown below:

<img width="618" alt="image" src="https://github.com/joonvena/Robot-Reporter/assets/3029781/693bd775-cfc5-4f2f-9df8-86050244dfef">
