### PR TITLE
Robot Framework elapsed time format fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,11 +122,10 @@ func main() {
 		name := test.SelectAttr("name")
 		status := test.SelectElement("status").SelectAttr("status")
 		suite := test.Parent.SelectAttr("name")
-		startTime := test.SelectElement("status").SelectAttr("starttime")
-		endTime := test.SelectElement("status").SelectAttr("endtime")
+		elapsed := test.SelectElement("status").SelectAttr("elapsed")
 		message := strings.ReplaceAll(test.SelectElement("status").InnerText(), "\n", " ")
 
-		executionTime, err := getExecutionTime(startTime, endTime)
+		executionTime, err := getExecutionTime(elapsed)
 		if err != nil {
 			log.Println(err)
 		}

--- a/utils.go
+++ b/utils.go
@@ -10,7 +10,7 @@ func getExecutionTime(elapsed string) (float64, error) {
 	// Convert string to float64
 	f, err := strconv.ParseFloat(elapsed, 64)
 	if err != nil {
-		return 0, err
+		return 0.0, err
 	}
 	return f, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -3,25 +3,16 @@ package main
 import (
 	"fmt"
 	"regexp"
-	"time"
+	"strconv"
 )
 
-const (
-	timeFormatLayout = "20060102 15:04:05,000"
-)
-
-func getExecutionTime(start string, end string) (float64, error) {
-	startTime, err := time.Parse(timeFormatLayout, start)
+func getExecutionTime(elapsed string) (float64, error) {
+	// Convert string to float64
+	f, err := strconv.ParseFloat(elapsed, 64)
 	if err != nil {
-		return 0.0, err
+		return 0, err
 	}
-	endTime, err := time.Parse(timeFormatLayout, end)
-	if err != nil {
-		return 0.0, err
-	}
-
-	diff := endTime.Sub(startTime)
-	return diff.Seconds(), nil
+	return f, nil
 }
 
 func resultCommentExists(comment string) bool {


### PR DESCRIPTION
GitHub Action does not show tests duration for Robot Framework 7.0 reports:

<img width="463" alt="2024-02-13_13h53_23" src="https://github.com/joonvena/Robot-Reporter/assets/743622/d6ae56b7-8294-480d-aa1d-485f9cf2c1ab">

Robot Framework elapsed time format fix accordingly to the output.xml file format in RF 7.0.

* added elapsed time instead of end time
* updated getExecutionTime

Verified the fix for my own DockerHub image and got following results:

<img width="456" alt="2024-02-14_12h00_54" src="https://github.com/joonvena/Robot-Reporter/assets/743622/a18c61f5-0255-4b43-8e82-73210ce99681">

