### PR TITLE
Fix broken duration due to changes in RF 7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/joonvena/robot-reporter
 go 1.14
 
 require (
-	github.com/antchfx/xmlquery v1.3.10 // indirect
+	github.com/antchfx/xmlquery v1.3.10
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -11,17 +13,27 @@ const (
 )
 
 func getExecutionTime(start string, end string) (float64, error) {
-	startTime, err := time.Parse(timeFormatLayout, start)
-	if err != nil {
-		return 0.0, err
-	}
-	endTime, err := time.Parse(timeFormatLayout, end)
-	if err != nil {
-		return 0.0, err
-	}
+	if end == "" {
+		// If end is empty, start contains the elapsed time
+		f, err := strconv.ParseFloat(start, 64)
+		if err != nil {
+			return 0.0, err
+		}
+		return f, nil
+	} else {
+		// If end is not empty, calculate the elapsed time using start and end times
+		startTime, err := time.Parse(timeFormatLayout, start)
+		if err != nil {
+			return 0.0, err
+		}
+		endTime, err := time.Parse(timeFormatLayout, end)
+		if err != nil {
+			return 0.0, err
+		}
 
-	diff := endTime.Sub(startTime)
-	return diff.Seconds(), nil
+		diff := endTime.Sub(startTime)
+		return diff.Seconds(), nil
+	}
 }
 
 func resultCommentExists(comment string) bool {
@@ -37,4 +49,9 @@ func passPercentage(passed int, failed int) string {
 		return fmt.Sprintf("%.2f", (float64(passed) / (float64(passed) + float64(failed)) * 100))
 	}
 	return "0"
+}
+
+func getRobotVersion(version string) int {
+	majorVersion, _ := strconv.Atoi(strings.Split(version, ".")[0])
+	return majorVersion
 }


### PR DESCRIPTION
Output schema was changed in the Robot Framework version 7. Make the parser work with RF version 7 and also make it backward compatible with older version.