### PR TITLE
fix: support both new and old RF formats for elapsed time

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -4,9 +4,28 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"time"
 )
 
-func getExecutionTime(elapsed string) (float64, error) {
+const (
+	timeFormatLayout = "20060102 15:04:05,000"
+)
+
+func getExecutionTimeV1(start string, end string) (float64, error) {
+	startTime, err := time.Parse(timeFormatLayout, start)
+	if err != nil {
+		return 0.0, err
+	}
+	endTime, err := time.Parse(timeFormatLayout, end)
+	if err != nil {
+		return 0.0, err
+	}
+
+	diff := endTime.Sub(startTime)
+	return diff.Seconds(), nil
+}
+
+func getExecutionTimeV2(elapsed string) (float64, error) {
 	// Convert string to float64
 	f, err := strconv.ParseFloat(elapsed, 64)
 	if err != nil {


### PR DESCRIPTION
Fix support for the test execution time by automatically detecting both the new and old RobotFramework time formats, so the reports work in both versions.

In RF 7.0, the execution time is provided in the `elapsed` attribute, and in < RF 7.0, only the `starttime` and `endtime` attributes are provided.

See the [RobotFramework 7.0 release notes for details](https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-7.0.rst#timestamp-related-changes)